### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pdf2txt.py
+++ b/pdf2txt.py
@@ -44,16 +44,16 @@ def parse_command_line(argv):
     
     parser.add_option("-d", "--dpi", action="store", 
                       type="int", dest="dpi", default=JPG_RESOLUTION_DPI,
-                      help="JPEG Resolution in DPI (default: %d)" % (JPG_RESOLUTION_DPI))
+                      help="JPEG Resolution in DPI (default: {0:d})".format((JPG_RESOLUTION_DPI)))
     parser.add_option("-j", "--jpgdir", action="store", 
                       type="string", dest="jpgdir", default=JPG_OUTPUT_DIR,
-                      help="JPEG output directory (default: %s)" % (JPG_OUTPUT_DIR))
+                      help="JPEG output directory (default: {0!s})".format((JPG_OUTPUT_DIR)))
     parser.add_option("-t", "--textdir", action="store", 
                       type="string", dest="txtdir", default=TEXT_OUTPUT_DIR,
-                      help="Text output directory (default: %s)" % (TEXT_OUTPUT_DIR))
+                      help="Text output directory (default: {0!s})".format((TEXT_OUTPUT_DIR)))
     parser.add_option("-r", "--resume", action="store_true", 
                       dest="resume", default=RESUME_OCR,
-                      help="Resume OCR to Text (default: %s)" % (RESUME_OCR))
+                      help="Resume OCR to Text (default: {0!s})".format((RESUME_OCR)))
     return parser.parse_args(argv)
     
 def getSize(filename):
@@ -76,7 +76,7 @@ def jpg_to_text(options, filename, rootdir):
     extdir = rootdir + '/' + os.path.dirname(relpath)
     fname = extdir + '/' + os.path.basename(relpath)
     fname = os.path.splitext(fname)[0]
-    print("OCR JPG to TEXT: %s" % (filename))
+    print("OCR JPG to TEXT: {0!s}".format((filename)))
     try:
         if not os.path.exists(extdir):
             os.makedirs(extdir)
@@ -101,7 +101,7 @@ def pdf_to_jpg(filename, rootdir, dpi):
     extdir = rootdir + '/' + os.path.dirname(relpath)
     fname = extdir + '/' + os.path.basename(relpath)
     fname = os.path.splitext(fname)[0] + '-%d.jpg'
-    print("Convert PDF to JPG: %s" % (filename))
+    print("Convert PDF to JPG: {0!s}".format((filename)))
     try:
         if not os.path.exists(extdir):
             os.makedirs(extdir)
@@ -144,7 +144,7 @@ if __name__ == "__main__":
     
     signal.signal(signal.SIGINT, signal_handler)
     
-    print("%s - r2 (2013/06/15)\n" % (os.path.basename(sys.argv[0])))
+    print("{0!s} - r2 (2013/06/15)\n".format((os.path.basename(sys.argv[0]))))
     
     (options, args) = parse_command_line(sys.argv)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:image-to-text?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:image-to-text?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)